### PR TITLE
Users can now add and view reactions!

### DIFF
--- a/SQL/02_TabloidMVC_Seed_Data.sql
+++ b/SQL/02_TabloidMVC_Seed_Data.sql
@@ -33,3 +33,23 @@ VALUES (
 'There are those' + char(10) + 'who do not believe' + char(10) + 'C# is the best.' + char(10) + 'They are wrong.',
     'https://gizmodiva.com/wp-content/uploads/2017/10/SCOTT-A-WOODWARD_1SW1943-1170x689.jpg',SYSDATETIME(), SYSDATETIME(), 1, 1, 1);
 SET IDENTITY_INSERT [Post] OFF
+
+SET IDENTITY_INSERT [Reaction] ON
+INSERT INTO [Reaction] ( [Id], [Name], [ImageLocation])
+VALUES (1, 'Like', 'https://www.pngkey.com/png/detail/45-451702_thumbs-up-emoji-png-transparent-thumbs-up-sticker.png');
+
+INSERT INTO [Reaction] ( [Id], [Name], [ImageLocation])
+VALUES (2, 'Love', 'https://toppng.com/uploads/preview/heart-emoji-11549911583t6kulc2slx.png');
+
+INSERT INTO [Reaction] ( [Id], [Name], [ImageLocation])
+VALUES (3, 'Laughing', 'https://www.clipartmax.com/png/middle/426-4265976_free-png-download-emoji-transparent-laughing-emoji-laugh-emoji-png-transparent.png');
+
+INSERT INTO [Reaction] ( [Id], [Name], [ImageLocation])
+VALUES (4, 'Wow', 'https://cdn.shopify.com/s/files/1/1061/1924/products/12_grande.png');
+
+INSERT INTO [Reaction] ( [Id], [Name], [ImageLocation])
+VALUES (5, 'Sad', 'https://toppng.com/uploads/preview/sad-emoji-11549513329eul5223kjq.png');
+
+INSERT INTO [Reaction] ( [Id], [Name], [ImageLocation])
+VALUES (6, 'Angry', 'https://cdn.shopify.com/s/files/1/1061/1924/products/Super_Angry_Face_Emoji_ios10_grande.png');
+SET IDENTITY_INSERT [Reaction] OFF

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -17,12 +17,16 @@ namespace TabloidMVC.Controllers
         private readonly IPostRepository _postRepository;
         private readonly ICategoryRepository _categoryRepository;
         private readonly ISubscriptionRepository _subscriptionRepository;
+        private readonly IPostReactionRepository _postReactionRepository;
+        private readonly IReactionRepository _reactionRepository;
 
-        public PostController(IPostRepository postRepository, ICategoryRepository categoryRepository, ISubscriptionRepository subscriptionRepository)
+        public PostController(IPostRepository postRepository, ICategoryRepository categoryRepository, ISubscriptionRepository subscriptionRepository, IPostReactionRepository postReactionRepository, IReactionRepository reactionRepository)
         {
             _postRepository = postRepository;
             _categoryRepository = categoryRepository;
             _subscriptionRepository = subscriptionRepository;
+            _postReactionRepository = postReactionRepository;
+            _reactionRepository = reactionRepository;
         }
 
         public IActionResult Index()
@@ -51,11 +55,16 @@ namespace TabloidMVC.Controllers
                 }
             }
 
+            List<Reaction> reactions = _reactionRepository.GetReactions();
+            List<PostReaction> postReactions = _postReactionRepository.GetPostReactionsByPostId(id);
+
             List<Subscription> mySubscriptions = _subscriptionRepository.GetUserSubscriptions(userId);
 
             PostDetailsViewModel vm = new PostDetailsViewModel();
 
             vm.Post = post;
+            vm.AllReactions = reactions;
+            vm.AllPostReactions = postReactions;
 
             foreach (Subscription subscription in mySubscriptions)
             {

--- a/TabloidMVC/Controllers/ReactionController.cs
+++ b/TabloidMVC/Controllers/ReactionController.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using TabloidMVC.Models;
+using TabloidMVC.Repositories;
+
+namespace TabloidMVC.Controllers
+{
+    public class ReactionController : Controller
+    {
+        private readonly IPostReactionRepository _postReactionRepository;
+        private readonly IReactionRepository _reactionRepository;
+
+        public ReactionController(IPostReactionRepository postReactionRepository, IReactionRepository reactionRepository)
+        {
+            _postReactionRepository = postReactionRepository;
+            _reactionRepository = reactionRepository;
+        }
+        public ActionResult React(int postId, int reactionId)
+        {
+            PostReaction postReaction = new PostReaction();
+            postReaction.PostId = postId;
+            postReaction.ReactionId = reactionId;
+            postReaction.UserProfileId = GetCurrentUserId();
+
+            _postReactionRepository.AddPostReaction(postReaction);
+
+            return RedirectToAction("Details", "Post", new { id = postId });
+
+        }
+
+        private int GetCurrentUserId()
+        {
+            string id = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            return int.Parse(id);
+        }
+    }
+}

--- a/TabloidMVC/Models/PostReaction.cs
+++ b/TabloidMVC/Models/PostReaction.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models
+{
+    public class PostReaction
+    {
+        public int Id { get; set; }
+        public int PostId { get; set; }
+        public int ReactionId { get; set; }
+        public int UserProfileId { get; set; }
+    }
+}

--- a/TabloidMVC/Models/Reaction.cs
+++ b/TabloidMVC/Models/Reaction.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace TabloidMVC.Models
+{
+    public class Reaction
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string ImageLocation { get; set; }
+    }
+}

--- a/TabloidMVC/Models/ViewModels/PostDetailsViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/PostDetailsViewModel.cs
@@ -9,5 +9,7 @@ namespace TabloidMVC.Models.ViewModels
     {        
         public Post Post { get; set; }        
         public Boolean Subscribed { get; set; }
+        public List<Reaction> AllReactions { get; set; }
+        public List<PostReaction> AllPostReactions { get; set; }
     }
 }

--- a/TabloidMVC/Repositories/IPostReactionRepository.cs
+++ b/TabloidMVC/Repositories/IPostReactionRepository.cs
@@ -9,5 +9,6 @@ namespace TabloidMVC.Repositories
     public interface IPostReactionRepository
     {
         public List<PostReaction> GetPostReactionsByPostId(int id);
+        public void AddPostReaction(PostReaction postReaction);
     }
 }

--- a/TabloidMVC/Repositories/IPostReactionRepository.cs
+++ b/TabloidMVC/Repositories/IPostReactionRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TabloidMVC.Models;
+
+namespace TabloidMVC.Repositories
+{
+    public interface IPostReactionRepository
+    {
+        public List<PostReaction> GetPostReactionsByPostId(int id);
+    }
+}

--- a/TabloidMVC/Repositories/IReactionRepository.cs
+++ b/TabloidMVC/Repositories/IReactionRepository.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TabloidMVC.Models;
+
+namespace TabloidMVC.Repositories
+{
+    public interface IReactionRepository
+    {
+        public List<Reaction> GetReactions();
+    }
+}

--- a/TabloidMVC/Repositories/PostReactionRepository.cs
+++ b/TabloidMVC/Repositories/PostReactionRepository.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Reflection.PortableExecutable;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using TabloidMVC.Models;
+using TabloidMVC.Utils;
+
+namespace TabloidMVC.Repositories
+{
+    public class PostReactionRepository: BaseRepository, IPostReactionRepository
+    {
+        public PostReactionRepository(IConfiguration config) : base(config) { }
+        public List<PostReaction> GetPostReactionsByPostId(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT r.Id, r.PostId, r.ReactionId, r.UserProfileId,
+                                        FROM Reaction
+                                        LEFT JOIN Post p ON p.Id = r.PostId
+                                        LEFT JOIN Reaction e ON e.Id = r.ReactionId
+                                        LEFT JOIN UserProfile u ON u.Id = r.UserProfileId
+                                        WHERE r.PostId = @id";
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    List<PostReaction> reactions = new List<PostReaction>();
+                    while (reader.Read())
+                    {
+                        PostReaction reaction = new PostReaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            PostId = reader.GetInt32(reader.GetOrdinal("PostId")),
+                            ReactionId = reader.GetInt32(reader.GetOrdinal("ReactionId")),
+                            UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileId"))
+                        };
+                        reactions.Add(reaction);
+                    }
+
+                    reader.Close();
+
+                    return reactions;
+                }
+            }
+        }
+
+        public void AddPostReaction(PostReaction postReaction)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        INSERT INTO PostReaction (
+                            PostId, ReactionId, UserProfileId )
+                        OUTPUT INSERTED.ID
+                        VALUES (
+                            @PostId, @ReactionId, @UserProfileId )";
+                    cmd.Parameters.AddWithValue("@PostId", postReaction.PostId);
+                    cmd.Parameters.AddWithValue("@ReactionId", postReaction.ReactionId);
+                    cmd.Parameters.AddWithValue("@UserProfileId", postReaction.UserProfileId);
+
+                    postReaction.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+    }
+}

--- a/TabloidMVC/Repositories/PostReactionRepository.cs
+++ b/TabloidMVC/Repositories/PostReactionRepository.cs
@@ -19,13 +19,13 @@ namespace TabloidMVC.Repositories
                 conn.Open();
                 using (SqlCommand cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = @"SELECT r.Id, r.PostId, r.ReactionId, r.UserProfileId,
-                                        FROM Reaction
+                    cmd.CommandText = @"SELECT r.Id, r.PostId, r.ReactionId, r.UserProfileId
+                                        FROM PostReaction r
                                         LEFT JOIN Post p ON p.Id = r.PostId
                                         LEFT JOIN Reaction e ON e.Id = r.ReactionId
                                         LEFT JOIN UserProfile u ON u.Id = r.UserProfileId
                                         WHERE r.PostId = @id";
-
+                    cmd.Parameters.AddWithValue("@id", id);
                     SqlDataReader reader = cmd.ExecuteReader();
 
                     List<PostReaction> reactions = new List<PostReaction>();

--- a/TabloidMVC/Repositories/ReactionRepository.cs
+++ b/TabloidMVC/Repositories/ReactionRepository.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using TabloidMVC.Models;
+
+namespace TabloidMVC.Repositories
+{
+    public class ReactionRepository: BaseRepository, IReactionRepository
+    {
+        public ReactionRepository(IConfiguration config) : base(config) { }
+
+        public List<Reaction> GetReactions()
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"SELECT Id, Name, ImageLocation FROM Reaction";
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    List<Reaction> reactions = new List<Reaction>();
+                    while (reader.Read())
+                    {
+                        Reaction reaction = new Reaction
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Name = reader.GetString(reader.GetOrdinal("Name")),
+                            ImageLocation = reader.GetString(reader.GetOrdinal("ImageLocation"))
+                        };
+                        reactions.Add(reaction);
+                    }
+
+                    reader.Close();
+
+                    return reactions;
+                }
+            }
+        }
+
+    }
+}

--- a/TabloidMVC/Startup.cs
+++ b/TabloidMVC/Startup.cs
@@ -31,6 +31,8 @@ namespace TabloidMVC
             services.AddTransient<ITagRepository, TagRepository>();
             services.AddTransient<ISubscriptionRepository, SubscriptionRepository>();
             services.AddTransient<IUserTypeRepository, UserTypeRepository>();
+            services.AddTransient<IPostReactionRepository, PostReactionRepository>();
+            services.AddTransient<IReactionRepository, ReactionRepository>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -50,8 +50,14 @@
             <a asp-controller="Comment" asp-action="Index" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Comments">
                 <i class="fas fa-comment-alt"></i>
             </a>
+            @foreach (Reaction reaction in Model.AllReactions)
+            {
+                <a asp-controller="Comment" asp-action="Create" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Add Comment">
+                    <img src="@reaction.ImageLocation" alt="@reaction.Name reaction" id="reactionImage" height="25px" width="25px"/>
+                </a>
+             }
 
-        </div>
+            </div>
 
     </div>
 </div>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -52,8 +52,8 @@
             </a>
             @foreach (Reaction reaction in Model.AllReactions)
             {
-                <a asp-controller="Comment" asp-action="Create" asp-route-id="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="Add Comment">
-                    <img src="@reaction.ImageLocation" alt="@reaction.Name reaction" id="reactionImage" height="25px" width="25px"/>
+                <a asp-controller="Reaction" asp-action="React" asp-route-reactionId="@reaction.Id" asp-route-postId="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="React">
+                    <img src="@reaction.ImageLocation" alt="@reaction.Name reaction" id="reactionImage" height="25px" width="25px" />
                 </a>
              }
 

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -52,9 +52,18 @@
             </a>
             @foreach (Reaction reaction in Model.AllReactions)
             {
+                int total = 0;
                 <a asp-controller="Reaction" asp-action="React" asp-route-reactionId="@reaction.Id" asp-route-postId="@Model.Post.Id" class="btn btn-outline-primary mx-1" title="React">
                     <img src="@reaction.ImageLocation" alt="@reaction.Name reaction" id="reactionImage" height="25px" width="25px" />
                 </a>
+                @foreach(PostReaction postReaction in Model.AllPostReactions)
+                {
+                    if(postReaction.ReactionId == reaction.Id)
+                    {
+                        total++;
+                    }
+                }
+                @total
              }
 
             </div>


### PR DESCRIPTION
To test this pull request, you'll have to update your database with the lines I've added to the seed SQL query.

After updating, navigate to a post details page and click a reaction.
Verify that the count increases!
Right now a user can infinitely add reactions to a post, but I may fix in future versions.

Verify that this request follows all guidelines in associated issues.